### PR TITLE
feat: allow nested objects in transition jsonpath

### DIFF
--- a/stream-consumer/app/fixtures/examples.py
+++ b/stream-consumer/app/fixtures/examples.py
@@ -56,8 +56,26 @@ BASE_TRANSFORMATION = {
 }
 
 BASE_TRANSITION = {
-    'input_map': {'ref': '$.source.ref'},
-    'output_map': {'ref': '$.ref'}
+    'input_map': {
+        'ref': '$.source.ref',
+        'const': 'a',
+        'list': [
+            '$.source.ref',
+            '$.source.ref'
+        ],
+        'dict': {
+            'a': '$.source.ref',
+            'b': 'b'
+        }
+    },
+    'output_map': {
+        'ref': '$.ref',
+        'list': ['$.list[0]'],
+        'const': 'c',
+        'dict': {
+            'f': '$.dict.a'
+        }
+    }
 }
 
 BASE_TRANSITION_PASS = dict(BASE_TRANSITION)

--- a/stream-consumer/app/helpers/pipeline.py
+++ b/stream-consumer/app/helpers/pipeline.py
@@ -81,7 +81,7 @@ class Transition:
                 for k, v in obj.items()
             }
             # filter out nones so key presence doesn't cause overwrite on merge
-            return {k: v for k, v in res.items() if v}
+            return {k: v for k, v in res.items() if v is not None}
 
     @staticmethod
     def apply_merge_dicts(_map: Dict, a: Dict, b: dict):

--- a/stream-consumer/app/helpers/pipeline.py
+++ b/stream-consumer/app/helpers/pipeline.py
@@ -31,6 +31,7 @@ from typing import (
     Iterable,
     List,
     Tuple,
+    Union,
 )
 
 from confluent_kafka import Producer as KafkaProducer
@@ -67,14 +68,20 @@ class Transition:
                 return [i.value for i in matches][0]
 
     @staticmethod
-    def apply_map(map: Dict, context: Dict) -> Dict:
-        _mapped = {
-            k: Transition.handle_parser_results(
-                CachedParser.find(v, context)) for
-            k, v in map.items()
-        }
-        # filter out nones so key presence doesn't cause overwrite on merge
-        return {k: v for k, v in _mapped.items() if v is not None}
+    def apply_map(obj: Union[str, List, Dict], context: Dict):
+        if isinstance(obj, str) and obj.startswith('$.'):
+            return Transition.handle_parser_results(CachedParser.find(obj, context))
+        elif isinstance(obj, str):
+            return obj
+        elif isinstance(obj, list):
+            return [Transition.apply_map(i, context) for i in obj]
+        elif isinstance(obj, dict):
+            res = {
+                k: Transition.apply_map(v, context)
+                for k, v in obj.items()
+            }
+            # filter out nones so key presence doesn't cause overwrite on merge
+            return {k: v for k, v in res.items() if v}
 
     @staticmethod
     def apply_merge_dicts(_map: Dict, a: Dict, b: dict):

--- a/stream-consumer/tests/test_unit.py
+++ b/stream-consumer/tests/test_unit.py
@@ -56,7 +56,12 @@ def test__Transformation_basic(BaseTransition):
     trans = transforms.Transformation('_id', examples.BASE_TRANSFORMATION, None)
     context = PipelineContext()
     context.register_result('source', {'ref': 200})
-    assert(trans.run(context, Transition(**examples.BASE_TRANSITION_PASS)) == {'ref': 200})
+    assert(trans.run(context, Transition(**examples.BASE_TRANSITION_PASS)) == {
+        'ref': 200,
+        'list': [200],
+        'const': 'c',
+        'dict': {'f': 200}
+    })
     context.register_result('source', {'ref': 500})
     with pytest.raises(TransformationError):
         trans.run(context, Transition(**examples.BASE_TRANSITION_PASS))


### PR DESCRIPTION
and combinations of constants and jsonpaths

now valid:
```json
{
  "a" : "constant",
  "b" : "$.jsonpath",
  "list" : [ "$.jsonpath", "constant"],
  "dict": {"a": "constant", "b" :"$.jsonpath"}
}
```
json paths will be resolved from context as normal no matter their placement in their heirarchy.