### PR TITLE
feat: kafka latest

### DIFF
--- a/stream-consumer/app/fixtures/examples.py
+++ b/stream-consumer/app/fixtures/examples.py
@@ -25,6 +25,7 @@ KAFKA_SUBSCRIPTION = {
     'id': 'sub-test',
     'name': 'Test Subscription',
     'topic_pattern': '*',
+    'auto_offset_reset': 'earliest',
     'topic_options': {
         'masking_annotation': '@aether_masking',  # schema key for mask level of a field
         'masking_levels': ['public', 'private'],  # classifications

--- a/stream-consumer/app/fixtures/schemas.py
+++ b/stream-consumer/app/fixtures/schemas.py
@@ -451,6 +451,18 @@ PIPELINE = '''
           ],
           "pattern": "^(.*)$"
         },
+        "auto_offset_reset": {
+          "$id": "#/properties/auto_offset_reset",
+          "type": "string",
+          "title": "Kafka Consumer -> (auto.offset.reset)",
+          "enum": ["earliest", "latest"],
+          "default": "earliest",
+          "examples": [
+            "earliest",
+            "latest"
+          ],
+          "pattern": "^(.*)$"
+        },
         "topic_options": {
           "$id": "#/properties/topic_options",
           "type": "object",

--- a/stream-consumer/app/helpers/pipeline.py
+++ b/stream-consumer/app/helpers/pipeline.py
@@ -292,7 +292,8 @@ class PipelinePubSub(object):
         args = {k.lower(): v for k, v in KAFKA_CONFIG.copy().items()}
         # the usual Kafka Client Configuration
         args['group.id'] = self.kafka_group_id
-        args['auto.offset.reset'] = self.definition['kafka_subscription'].get('auto_offset_reset', 'earliest')
+        args['auto.offset.reset'] = \
+            self.definition['kafka_subscription'].get('auto_offset_reset', 'earliest')
         self.kafka_consumer = KafkaConsumer(**args)
         pattern = self.definition['kafka_subscription'].get('topic_pattern', '*')
         # only allow regex on the end of patterns

--- a/stream-consumer/app/helpers/pipeline.py
+++ b/stream-consumer/app/helpers/pipeline.py
@@ -290,7 +290,9 @@ class PipelinePubSub(object):
 
     def __make_kafka_getter(self):
         args = {k.lower(): v for k, v in KAFKA_CONFIG.copy().items()}
+        # the usual Kafka Client Configuration
         args['group.id'] = self.kafka_group_id
+        args['auto.offset.reset'] = self.definition['kafka_subscription'].get('auto_offset_reset', 'earliest')
         self.kafka_consumer = KafkaConsumer(**args)
         pattern = self.definition['kafka_subscription'].get('topic_pattern', '*')
         # only allow regex on the end of patterns

--- a/stream-consumer/conf/pip/primary-requirements.txt
+++ b/stream-consumer/conf/pip/primary-requirements.txt
@@ -9,7 +9,7 @@
 #################################################################################################
 
 # Consumer
-aet.consumer
+aet.consumer>=3.10.1
 aether.python
 dnspython
 quickjs

--- a/stream-consumer/conf/pip/requirements.txt
+++ b/stream-consumer/conf/pip/requirements.txt
@@ -8,22 +8,25 @@
 # then run 'docker-compose run myconsumer pip_freeze'                                   #
 #                                                                              		    #
 #########################################################################################
-aet.consumer==3.9.2
-aether.python==1.2.0
+aet.consumer==3.10.1
+aether.python==1.3.0
 attrs==19.3.0
+avro-python3==1.10.1
 beautifulsoup4==4.8.2
 certifi==2019.11.28
+cffi==1.14.4
 chardet==3.0.4
 click==7.1.1
 confluent-kafka==1.5.0
-coverage==5.1
+coverage==5.3.1
+cryptography==3.3.1
 decorator==4.4.2
-dnspython==2.0.0
+dnspython==2.1.0
 eha-jsonpath==0.5.1
 entrypoints==0.3
 flake8==3.8.4
 Flask==1.1.1
-grpcio==1.33.2
+grpcio==1.34.0
 idna==2.9
 importlib-metadata==1.6.0
 iniconfig==1.1.1
@@ -39,14 +42,16 @@ more-itertools==8.2.0
 packaging==20.3
 pluggy==0.13.1
 ply==3.11
-protobuf==3.13.0
+protobuf==3.14.0
 py==1.9.0
 pycodestyle==2.6.0
+pycparser==2.20
 pyflakes==2.2.0
+pyOpenSSL==20.0.1
 pyparsing==2.4.6
 pyrsistent==0.16.0
 pytest==6.2.1
-pytest-cov==2.10.1
+pytest-cov==2.11.1
 pytest-runner==5.2
 quickjs==1.15.1
 redis==3.4.1
@@ -62,5 +67,5 @@ wcwidth==0.1.9
 WebOb==1.8.6
 WebTest==2.0.34
 Werkzeug==1.0.1
-zeebe-grpc==0.25.1.0
+zeebe-grpc==0.26.0.0
 zipp==3.1.0


### PR DESCRIPTION
- expose the `auto.offset.reset` property of the Kafka Consumer as part of the `kafka_subscription` definition.
  - https://docs.confluent.io/platform/current/clients/consumer.html#id1
- Valid values are `earliest` and `latest`, with the default remaining `earliest`
  - see schemas.py / examples.py for syntax